### PR TITLE
Add generic type parameter to WatchBoxBuilder

### DIFF
--- a/lib/src/watch_box_builder.dart
+++ b/lib/src/watch_box_builder.dart
@@ -1,11 +1,11 @@
 part of hive_flutter;
 
 /// Signature for a function that builds a widget given a [Box].
-typedef BoxWidgetBuilder = Widget Function(BuildContext context, Box box);
+typedef BoxWidgetBuilder<E> = Widget Function(BuildContext context, Box<E> box);
 
 /// A general-purpose widget which rebuilds itself when the box or a specific
 /// key change.
-class WatchBoxBuilder extends StatefulWidget {
+class WatchBoxBuilder<E> extends StatefulWidget {
   /// Creates a widget that rebuilds itself when a value in the [box] changes.
   ///
   /// If you specify [watchKeys], the widget only refreshes when a value
@@ -20,19 +20,19 @@ class WatchBoxBuilder extends StatefulWidget {
         super(key: key);
 
   /// The box which should be watched.
-  final Box box;
+  final Box<E> box;
 
   /// Called every time the box changes. The builder must not return null.
-  final BoxWidgetBuilder builder;
+  final BoxWidgetBuilder<E> builder;
 
   /// Specifies which keys should be watched.
   final List<String> watchKeys;
 
   @override
-  _WatchBoxBuilderState createState() => _WatchBoxBuilderState();
+  _WatchBoxBuilderState<E> createState() => _WatchBoxBuilderState<E>();
 }
 
-class _WatchBoxBuilderState extends State<WatchBoxBuilder> {
+class _WatchBoxBuilderState<E> extends State<WatchBoxBuilder<E>> {
   @visibleForTesting
   StreamSubscription subscription;
 
@@ -44,7 +44,7 @@ class _WatchBoxBuilderState extends State<WatchBoxBuilder> {
   }
 
   @override
-  void didUpdateWidget(WatchBoxBuilder oldWidget) {
+  void didUpdateWidget(WatchBoxBuilder<E> oldWidget) {
     super.didUpdateWidget(oldWidget);
 
     if (widget.box != oldWidget.box) {


### PR DESCRIPTION
This would allow for an easy way to gain the benefits of type-checking (including IDE autocompletion of fields) on the methods of the generic `Box<E>` type from the main library.

Example client code:
```dart
WatchBoxBuilder<Person>(
  box: getPersonBoxFromDI(),
  builder: (context, box) {
    var dave = box.get("dave"); // dave is known to be a Person because box is a Box<Person>
    return PersonWidget(person: dave);
  },
),
```

Without the generic parameter, the easiest ways to approximate this functionality would be to ignore the `box` parameter and call `getPersonBoxFromDI()` within the closure or cast `box` into a `Box<Person>`. The former might not be possible if the `builder` callback is a function or method instead of a closure and the latter is somewhat clunky.

This would not break any existing code; if omitted, the generic parameter is assumed to be `dynamic`, which is no different from before.